### PR TITLE
Fix compilation on Debian Stretch

### DIFF
--- a/examples/SecureUploader/SecureUploader.pro
+++ b/examples/SecureUploader/SecureUploader.pro
@@ -19,4 +19,4 @@ HEADERS  += \
     securefileuploader.h
 
 include(../../qssh.pri) ## Required for IDE_LIBRARY_PATH and qtLibraryName
-LIBS += -L$$IDE_LIBRARY_PATH -l$$qtLibraryName(Botan) -l$$qtLibraryName(QSsh)
+LIBS += -L$$IDE_LIBRARY_PATH -l$$qtLibraryName(botan-1.10) -l$$qtLibraryName(QSsh)

--- a/src/libs/libs.pro
+++ b/src/libs/libs.pro
@@ -2,5 +2,5 @@ TEMPLATE  = subdirs
 CONFIG   += ordered
 
 SUBDIRS   = \
-    3rdparty \
     ssh
+#    3rdparty \

--- a/src/libs/ssh/ssh.pro
+++ b/src/libs/ssh/ssh.pro
@@ -2,7 +2,6 @@ TEMPLATE = lib
 TARGET = QSsh
 QT += network
 DEFINES += QSSH_LIBRARY
-
 #Enable debug log
 #DEFINES += CREATOR_SSH_DEBUG
 

--- a/src/libs/ssh/ssh_dependencies.pri
+++ b/src/libs/ssh/ssh_dependencies.pri
@@ -1,1 +1,2 @@
-include(../3rdparty/botan/botan.pri)
+#include(../3rdparty/botan/botan.pri)
+INCLUDEPATH = /usr/include/botan-1.10 $$INCLUDEPATH

--- a/src/libs/ssh/sshcryptofacility.cpp
+++ b/src/libs/ssh/sshcryptofacility.cpp
@@ -37,7 +37,11 @@
 #include "sshkeypasswordretriever_p.h"
 #include "sshpacket_p.h"
 
-#include <botan/botan.h>
+#include <botan/cbc.h>
+#include <botan/pkcs8.h>
+#include <botan/dsa.h>
+#include <botan/rsa.h>
+#include <botan/pubkey.h>
 
 #include <QDebug>
 #include <QList>

--- a/src/libs/ssh/sshcryptofacility_p.h
+++ b/src/libs/ssh/sshcryptofacility_p.h
@@ -32,6 +32,7 @@
 #define SSHABSTRACTCRYPTOFACILITY_P_H
 
 #include <botan/botan.h>
+#include <botan/hmac.h>
 
 #include <QByteArray>
 #include <QScopedPointer>

--- a/src/libs/ssh/sshkeyexchange.cpp
+++ b/src/libs/ssh/sshkeyexchange.cpp
@@ -37,6 +37,11 @@
 #include "sshincomingpacket_p.h"
 
 #include <botan/botan.h>
+#include <botan/dl_group.h>
+#include <botan/rsa.h>
+#include <botan/dsa.h>
+#include <botan/dh.h>
+#include <botan/pubkey.h>
 
 #ifdef CREATOR_SSH_DEBUG
 #include <iostream>

--- a/src/libs/ssh/sshkeygenerator.cpp
+++ b/src/libs/ssh/sshkeygenerator.cpp
@@ -35,6 +35,10 @@
 #include "sshpacket_p.h"
 
 #include <botan/botan.h>
+#include <botan/rsa.h>
+#include <botan/der_enc.h>
+#include <botan/dsa.h>
+#include <botan/pem.h>
 
 #include <QDateTime>
 #include <QInputDialog>

--- a/src/libs/ssh/sshkeypasswordretriever_p.h
+++ b/src/libs/ssh/sshkeypasswordretriever_p.h
@@ -31,6 +31,7 @@
 #define KEYPASSWORDRETRIEVER_H
 
 #include <botan/botan.h>
+#include <botan/ui.h>
 
 #include <string>
 


### PR DESCRIPTION
The current master does not compile on Debian Stretch with Qt5. This commit fixes compilation on this system by using the system's botan library from the libbotan1.10-dev package.